### PR TITLE
bigcouch / cloudant support for couchexport

### DIFF
--- a/couchexport/export.py
+++ b/couchexport/export.py
@@ -88,7 +88,7 @@ class ExportConfiguration(object):
 
     def create_new_checkpoint(self):
         checkpoint = ExportSchema(
-            seq=self.current_seq, schema=self.get_latest_schema(),
+            seq=str(self.current_seq), schema=self.get_latest_schema(),
             timestamp=self.timestamp, index=self.schema_index)
         checkpoint.save()
         return checkpoint
@@ -165,7 +165,6 @@ def export(schema_index, file, format=Format.XLS_2007,
     Exports data from couch documents matching a given tag to a file. 
     Returns true if it finds data, otherwise nothing
     """
-
     config, updated_schema, export_schema_checkpoint = get_export_components(schema_index,
                                                                     previous_export_id, filter)
     # transform docs onto output and save

--- a/couchexport/tests/test_schema.py
+++ b/couchexport/tests/test_schema.py
@@ -7,7 +7,7 @@ class ExportSchemaTest(TestCase):
 
     def testSaveAndLoad(self):
         index = ["foo", 2]
-        schema = ExportSchema(seq=5, index=index)
+        schema = ExportSchema(seq="5", index=index)
         inner = {"dict": {"bar": 1, "baz": [2,3]},
                  "list": ["foo", "bar"],
                  "dictlist": [{"bip": 1, "bop": "blah"},
@@ -23,18 +23,18 @@ class ExportSchemaTest(TestCase):
         indices = ["a string", ["a", "list"]]
         for index in indices:
             self.assertEqual(None, ExportSchema.last(index))
-            schema1 = ExportSchema(seq=2, index=index)
+            schema1 = ExportSchema(seq="2", index=index)
             schema1.save()
             self.assertEqual(schema1._id, ExportSchema.last(index)._id)
-            schema2 = ExportSchema(seq=3, index=index)
+            schema2 = ExportSchema(seq="3", index=index)
             schema2.save()
             self.assertEqual(schema2._id, ExportSchema.last(index)._id)
             # by design, if something has a timestamp it always wins out, even
             # if something has a higher seq
-            schema3 = ExportSchema(seq=1, index=index, timestamp=datetime.utcnow())
+            schema3 = ExportSchema(seq="1", index=index, timestamp=datetime.utcnow())
             schema3.save()
             self.assertEqual(schema3._id, ExportSchema.last(index)._id)
             time.sleep(.1)
-            schema4 = ExportSchema(seq=1, index=index, timestamp=datetime.utcnow())
+            schema4 = ExportSchema(seq="1", index=index, timestamp=datetime.utcnow())
             schema4.save()
             self.assertEqual(schema4._id, ExportSchema.last(index)._id)


### PR DESCRIPTION
- should be non-breaking for couch as well
- convert seq property to a string
- add notifications when we try to export by seq (is deprecated)
- only do seq-based comparisons if we are on regular couch
- update tests
