### PR TITLE
remove sheet_name from any incoming SavedExportSchema in wrap

### DIFF
--- a/couchexport/models.py
+++ b/couchexport/models.py
@@ -636,6 +636,13 @@ class SavedExportSchema(BaseSavedExportSchema, UnicodeMixIn):
 
     sheet_name = property(__get_sheet_name, __set_sheet_name)
 
+    @classmethod
+    def wrap(cls, data):
+        # since this is a property now, trying to wrap it will fail hard
+        if 'sheet_name' in data:
+            del data['sheet_name']
+        return super(SavedExportSchema, cls).wrap(data)
+
 
 class ExportConfiguration(DocumentSchema):
     """


### PR DESCRIPTION
docs with this old structure were failing to wrap
because sheet_name is a property now, and cannot be manually set

(or actually, it has a setter, but that setter accesses variables which aren't accessible until after wrap is complete—bit of a race condition)
