### PR TITLE
use jsonobject-couchdbkit

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,14 +4,14 @@ from setuptools import setup, find_packages
 
 setup(
     name='couchexport',
-    version='0.0.1.2',
+    version='0.0.2',
     description='Dimagi Couch Exporter for Django',
     author='Dimagi',
     author_email='information@dimagi.com',
     url='http://www.dimagi.com/',
     install_requires = [
         "django",
-        "couchdbkit",
+        "jsonobject-couchdbkit",
         "dimagi-utils",
         'django-soil',
         "openpyxl",


### PR DESCRIPTION
so that https://github.com/dimagi/couchforms/pull/106 doesn't accidentally pull in couchdbkit as a requirement
