### PR TITLE
remove deprecated support for seq IDs in couchexport

### DIFF
--- a/couchexport/_design/views/schema_checkpoints/map.js
+++ b/couchexport/_design/views/schema_checkpoints/map.js
@@ -1,6 +1,5 @@
 function(doc) {
     if (doc.doc_type == "ExportSchema") {
-        emit(['by_timestamp', doc.index, doc.timestamp], null);
-        emit(['by_seq', doc.index, doc.seq], null);
+        emit([doc.index, doc.timestamp], null);
     }
 }

--- a/couchexport/exceptions.py
+++ b/couchexport/exceptions.py
@@ -8,10 +8,6 @@ class CustomExportValidationError(CouchExportException):
     pass
 
 
-class ExportBadStateException(CouchExportException):
-    pass
-
-
 class SchemaInferenceError(CouchExportException):
     pass
 

--- a/couchexport/export.py
+++ b/couchexport/export.py
@@ -26,7 +26,6 @@ class ExportConfiguration(object):
         self.schema_index = schema_index
         self.previous_export = previous_export
         self.filter = filter
-        self.current_seq = self.database.info()["update_seq"]
         self.timestamp = datetime.utcnow()
         self.potentially_relevant_ids = self._potentially_relevant_ids()
         self.disable_checkpoints = disable_checkpoints
@@ -99,8 +98,10 @@ class ExportConfiguration(object):
 
     def create_new_checkpoint(self):
         checkpoint = ExportSchema(
-            seq=str(self.current_seq), schema=self.get_latest_schema(),
-            timestamp=self.timestamp, index=self.schema_index)
+            schema=self.get_latest_schema(),
+            timestamp=self.timestamp,
+            index=self.schema_index,
+        )
         checkpoint.save()
         return checkpoint
 

--- a/couchexport/schema.py
+++ b/couchexport/schema.py
@@ -11,17 +11,6 @@ def build_latest_schema(schema_index):
     from couchexport.export import ExportConfiguration
     db = Database(settings.COUCH_DATABASE)
     previous_export = ExportSchema.last(schema_index)
-    try:
-        current_seq = int(db.info()["update_seq"])
-    except ValueError:
-        pass # we must be on bigcouch, so comparing seqs is useless
-    else:
-        if previous_export and not previous_export.is_bigcouch \
-                           and int(previous_export.seq) > current_seq:
-            # something weird happened (like the couch database changing)
-            # better rebuild from scratch
-            previous_export = None
-
     config = ExportConfiguration(db, schema_index,
                                  previous_export=previous_export)
     schema = config.get_latest_schema()

--- a/couchexport/tests/test_schema.py
+++ b/couchexport/tests/test_schema.py
@@ -8,7 +8,7 @@ class ExportSchemaTest(TestCase):
 
     def testSaveAndLoad(self):
         index = ["foo", 2]
-        schema = ExportSchema(seq="5", index=index, timestamp=datetime.now())
+        schema = ExportSchema(index=index, timestamp=datetime.now())
         inner = {"dict": {"bar": 1, "baz": [2,3]},
                  "list": ["foo", "bar"],
                  "dictlist": [{"bip": 1, "bop": "blah"},
@@ -26,16 +26,13 @@ class ExportSchemaTest(TestCase):
 
         for index in indices:
             self.assertEqual(None, ExportSchema.last(index))
-            # by design, if something has a timestamp it always wins out, even
-            # if something has a higher seq
-
             dt = datetime.utcnow()
-            schema1 = ExportSchema(seq="2", index=index, timestamp=dt)
+            schema1 = ExportSchema(index=index, timestamp=dt)
             schema1.save(**save_args)
             self.assertEqual(schema1._id, ExportSchema.last(index)._id)
-            schema2 = ExportSchema(seq="1", index=index, timestamp=dt + timedelta(seconds=1))
+            schema2 = ExportSchema(index=index, timestamp=dt + timedelta(seconds=1))
             schema2.save(**save_args)
             self.assertEqual(schema2._id, ExportSchema.last(index)._id)
-            schema3 = ExportSchema(seq="3", index=index, timestamp=dt - timedelta(seconds=1))
+            schema3 = ExportSchema(index=index, timestamp=dt - timedelta(seconds=1))
             schema3.save(**save_args)
             self.assertEqual(schema2._id, ExportSchema.last(index)._id)


### PR DESCRIPTION
The original version of couchexport used database-level `seq` IDs to determine which documents you had seen and which you hadn't. This presented a number of problems:
1. It was incredibly slow to walk the changes feed.
2. It incorrectly would include forms that were later saved e.g. during a migration, as being "new".
3. If you ever replicated it completely broke everything (this happened when we moved from old HQ to cloudant and was the impetus for the switch).

In the transition process we left around a good bit of code to support the deprecated workflow (and converted things just-in-time). This change removes that support entirely, and if you try to reference a checkpoint from the old scheme it will notify us that happened, but just act like you requested a non-checkpointed export (including everything).

this had been annoying me for a while, and making the code more cluttered than it needs to be so i just decided to kill it. 
