### PR TITLE
make couchexport more surgical about not leaving temp files around

### DIFF
--- a/couchexport/tasks.py
+++ b/couchexport/tasks.py
@@ -118,7 +118,7 @@ def cache_file_to_be_served(tmp, checkpoint, download_id, format=None, filename=
                         content_disposition='attachment; filename="%s"' % escaped_filename,
                         extras={'X-CommCareHQ-Export-Token': checkpoint.get_id},
                         download_id=download_id)
-
+        tmp.delete()
     else:
         # this just gives you a link saying there wasn't anything there
         expose_download("Sorry, there wasn't any data.", expiry,

--- a/couchexport/writers.py
+++ b/couchexport/writers.py
@@ -178,6 +178,7 @@ class CsvExportWriter(ExportWriter):
             tmpfile, path = self.table_files[index]
             tmpfile.close()
             archive.write(path, "%s.csv" % name)
+            os.remove(path)
         archive.close()
         self.file.seek(0)
 


### PR DESCRIPTION
handful of semi-related changes to better clean up files.

in response to http://manage.dimagi.com/default.asp?123162 and http://manage.dimagi.com/default.asp?102956
