### PR TITLE
use new urls module

### DIFF
--- a/couchexport/urls.py
+++ b/couchexport/urls.py
@@ -1,4 +1,4 @@
-from django.conf.urls.defaults import *
+from django.conf.urls import *
 
 urlpatterns = patterns('',
     url(r'^model/$', 'couchexport.views.export_data', name='model_download_excel'),


### PR DESCRIPTION
django.conf.urls.defaults is deprecated and removed in Django 1.6