### PR TITLE
Refactor `HtmlExportWriter` to not build tables in memory

### DIFF
--- a/couchexport/export.py
+++ b/couchexport/export.py
@@ -108,7 +108,6 @@ class ExportConfiguration(object):
 
 def get_writer(format):
     try:
-        # The dissymmetry between html and csv zipped/unzipped makes me sad
         return {
             Format.CSV: writers.CsvExportWriter,
             Format.HTML: writers.HtmlExportWriter,

--- a/couchexport/export.py
+++ b/couchexport/export.py
@@ -108,9 +108,11 @@ class ExportConfiguration(object):
 
 def get_writer(format):
     try:
+        # The dissymmetry between html and csv zipped/unzipped makes me sad
         return {
             Format.CSV: writers.CsvExportWriter,
             Format.HTML: writers.HtmlExportWriter,
+            Format.ZIPPED_HTML: writers.ZippedHtmlExportWriter,
             Format.JSON: writers.JsonExportWriter,
             Format.XLS: writers.Excel2003ExportWriter,
             Format.XLS_2007: writers.Excel2007ExportWriter,

--- a/couchexport/models.py
+++ b/couchexport/models.py
@@ -52,6 +52,7 @@ class Format(object):
     XLS = "xls"
     XLS_2007 = "xlsx"
     HTML = "html"
+    ZIPPED_HTML = "zipped-html"
     JSON = "json"
     UNZIPPED_CSV = 'unzipped-csv'
 
@@ -70,6 +71,9 @@ class Format(object):
                    HTML: {"mimetype": "text/html; charset=utf-8",
                           "extension": "html",
                           "download": False},
+                   ZIPPED_HTML: {"mimetype": "application/zip",
+                                 "extension": "zip",
+                                 "download": True},
                    JSON: {"mimetype": "application/json",
                           "extension": "json",
                           "download": False},

--- a/couchexport/templates/couchexport/html_export.html
+++ b/couchexport/templates/couchexport/html_export.html
@@ -1,33 +1,47 @@
+{% if section == "doc_begin" %}
 <!DOCTYPE HTML>
 <html>
 <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 </head>
 <body>
-{% for table_name, table in tables.items %}
-    <h2>{{ table_name }}</h2>
-    <table>
-    <thead>
-    {% for row in table %}
-        {% if forloop.first %}
-            <tr>
-                {% for cell in row %}
-                    <th>{{ cell }}</th>
-                {% endfor %}
-            </tr>
+{% endif %}
 
-            </thead>
-            <tbody>
-        {% else %}
-            <tr>
-                {% for cell in row %}
-                    <td>{{ cell }}</td>
-                {% endfor %}
-            </tr>
-        {% endif %}
-    {% endfor %}
+{% if section == "table_begin" %}
+    <h2>{{ name }}</h2>
+    <table>
+{% endif %}
+
+{% if section == "first_row" %}
+        <thead>
+        <tr>
+            {% for cell in row %}
+                <th>{{ cell }}</th>
+            {% endfor %}
+        </tr>
+
+        </thead>
+        <tbody>
+{% endif %}
+
+{% if section == "row" %}
+    <tr>
+        {% for cell in row %}
+            <td>{{ cell }}</td>
+        {% endfor %}
+    </tr>
+{% endif %}
+
+{% if section == "no_rows" %}
+    <tbody>
+{% endif %}
+
+{% if section == "table_end" %}
 </tbody>
 </table>
-{% endfor %}
+{% endif %}
+
+{% if section == "doc_end" %}
 </body>
 </html>
+{% endif %}

--- a/couchexport/tests/test_raw.py
+++ b/couchexport/tests/test_raw.py
@@ -45,3 +45,6 @@ class ExportRawTest(TestCase):
                 tables[key] = itertools.chain([headers[key]], data[key])
 
             export_from_tables(tables.items(), buffer, format=Format.JSON)
+
+    def test_my_stuff(self):
+        self.assertEqual(True, False)

--- a/couchexport/tests/test_raw.py
+++ b/couchexport/tests/test_raw.py
@@ -45,6 +45,3 @@ class ExportRawTest(TestCase):
                 tables[key] = itertools.chain([headers[key]], data[key])
 
             export_from_tables(tables.items(), buffer, format=Format.JSON)
-
-    def test_my_stuff(self):
-        self.assertEqual(True, False)

--- a/couchexport/writers.py
+++ b/couchexport/writers.py
@@ -457,9 +457,7 @@ class HtmlExportWriter(OnDiskExportWriter):
 
             table_writer = self.tables[index]
             self.file.write(render_to_string(
-                "couchexport/html_export.html", {"section": "table_begin", "name": index}
-                # TODO: Should name actually be name?
-                #       Existing behavior uses index
+                "couchexport/html_export.html", {"section": "table_begin", "name": name}
             ).encode("utf-8"))
 
             for line in table_writer.get_file():

--- a/couchexport/writers.py
+++ b/couchexport/writers.py
@@ -43,7 +43,7 @@ class UniqueHeaderGenerator(object):
 
 class ExportFileWriter(object):
 
-    def __init__(self,):
+    def __init__(self):
         self.name = None
         self._isopen = False
         self._file = None


### PR DESCRIPTION
`HtmlExportWriter` would load all of its tables into memory before rendering a django template. Now it builds the HTML file on disk incrementally as `write_row` is called. This PR also introduces a more generic `OnDiskExportWriter` that others can extend.

There aren't any tests for these classes, so it might be good to hold off merging until those are written.

Relates to this: http://manage.dimagi.com/default.asp?158653