### PR TITLE
Add tests for unzipped html and csv exports

### DIFF
--- a/couchexport/tests/expected.csv
+++ b/couchexport/tests/expected.csv
@@ -1,0 +1,2 @@
+unicodé,"comm,as<"
+more व,"<p> , commas , </p>"

--- a/couchexport/tests/expected.html
+++ b/couchexport/tests/expected.html
@@ -1,0 +1,69 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+</head>
+<body>
+    <h2>tricks</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>unicod&#233;</th>
+                <th>comm,as&lt;</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>more &#2357;</td>
+                <td>&lt;p&gt; , commas , &lt;/p&gt;</td>
+            </tr>
+        </tbody>
+    </table>
+    <h2>offices</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>location</th>
+                <th>name</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>Delhi, India</td>
+                <td>DSI</td>
+            </tr>
+            <tr>
+                <td>Boston, USA</td>
+                <td>Dimagi, Inc</td>
+            </tr>
+            <tr>
+                <td>Capetown, South Africa</td>
+                <td>DSA</td>
+            </tr>
+        </tbody>
+    </table>
+    <h2>people</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>name</th>
+                <th>gender</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td>danny</td>
+                <td>male</td>
+            </tr>
+            <tr>
+                <td>amelia</td>
+                <td>female</td>
+            </tr>
+            <tr>
+                <td>carter</td>
+                <td>various</td>
+            </tr>
+        </tbody>
+    </table>
+</body>
+</html>

--- a/couchexport/tests/test_raw.py
+++ b/couchexport/tests/test_raw.py
@@ -1,47 +1,84 @@
-from StringIO import StringIO
-import json
-from django.test import TestCase
 import itertools
+import json
+import os
+from StringIO import StringIO
+from django.test import SimpleTestCase
+from corehq.apps.app_manager.tests import TestFileMixin
 from couchexport.export import export_raw, export_from_tables
 from couchexport.models import Format
 
-class ExportRawTest(TestCase):
+HEADERS = (('people', ('name', 'gender')), ('offices', ('location', 'name')), ('tricks', (u'unicod\u00E9', 'comm,as<')))
+DATA = (
+    ('people', [('danny', 'male'), ('amelia', 'female'), ('carter', 'various')]),
+    ('offices', [('Delhi, India', 'DSI'), ('Boston, USA', 'Dimagi, Inc'), ('Capetown, South Africa', 'DSA')]),
+    ('tricks', [(u'more \u0935', u'<p> , commas , </p>')])
+)
+EXPECTED = {"tricks": {"headers": [u'unicod\u00E9', 'comm,as<'], "rows": [[u'more \u0935', u'<p> , commas , </p>']]}, "offices": {"headers": ["location", "name"], "rows": [["Delhi, India", "DSI"], ["Boston, USA", "Dimagi, Inc"], ["Capetown, South Africa", "DSA"]]}, "people": {"headers": ["name", "gender"], "rows": [["danny", "male"], ["amelia", "female"], ["carter", "various"]]}}
+
+
+class Tester(object):
+
+    def __init__(self, test_case, format):
+        self.test_case = test_case
+        self.format = format
+
+    def __enter__(self):
+        self.buffer = StringIO()
+        return self.buffer
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        if exc_type is None:
+            if self.format == Format.JSON:
+                self.test_case.assertDictEqual(json.loads(self.buffer.getvalue()), EXPECTED)
+
+            if self.format == Format.HTML:
+                path = os.path.join(os.path.dirname(__file__), "expected.html")
+                with open(path, 'r') as f:
+                    expected = f.read()
+                self.test_case.assertHtmlEqual(expected,self.buffer.getvalue())
+
+            if self.format == Format.UNZIPPED_CSV:
+                path = os.path.join(os.path.dirname(__file__), "expected.csv")
+                with open(path, 'r') as f:
+                    expected = f.read()
+                self.test_case.assertEqual(expected, self.buffer.getvalue())
+
+        self.buffer.close()
+
+
+class ExportRawTest(SimpleTestCase, TestFileMixin):
 
     def test_export_raw(self):
-        headers = (('people', ('name', 'gender')), ('offices', ('location', 'name')))
-        data = (
-            ('people', [('danny', 'male'), ('amelia', 'female'), ('carter', 'various')]),
-            ('offices', [('Delhi, India', 'DSI'), ('Boston, USA', 'Dimagi, Inc'), ('Capetown, South Africa', 'DSA')])
-        )
-        EXPECTED = {"offices": {"headers": ["location", "name"], "rows": [["Delhi, India", "DSI"], ["Boston, USA", "Dimagi, Inc"], ["Capetown, South Africa", "DSA"]]}, "people": {"headers": ["name", "gender"], "rows": [["danny", "male"], ["amelia", "female"], ["carter", "various"]]}}
 
-        that = self
-        class Tester(object):
-            def __enter__(self):
-                self.buffer = StringIO()
-                return self.buffer
-            def __exit__(self, exc_type, exc_val, exc_tb):
-                if exc_type is None:
-                    that.assertDictEqual(json.loads(self.buffer.getvalue()), EXPECTED)
-                self.buffer.close()
+        with Tester(self, Format.JSON) as buffer:
+            export_raw(HEADERS, DATA, buffer, format=Format.JSON)
 
-        with Tester() as buffer:
-            export_raw(headers, data, buffer, format=Format.JSON)
-
-        with Tester() as buffer:
+        with Tester(self, Format.JSON) as buffer:
             # test lists
-            export_raw(list(headers), list(data), buffer, format=Format.JSON)
+            export_raw(list(HEADERS), list(DATA), buffer, format=Format.JSON)
 
-        with Tester() as buffer:
+        with Tester(self, Format.JSON) as buffer:
             # test generators
-            export_raw((h for h in headers), ((name, (r for r in rows)) for name, rows in data), buffer, format=Format.JSON)
+            export_raw((h for h in HEADERS), ((name, (r for r in rows)) for name, rows in DATA), buffer, format=Format.JSON)
             
-        with Tester() as buffer:
+        with Tester(self, Format.JSON) as buffer:
             # test export_from_tables
-            headers = dict(headers)
-            data = dict(data)
+            headers = dict(HEADERS)
+            data = dict(DATA)
             tables = {}
             for key in set(headers.keys()) | set(data.keys()):
                 tables[key] = itertools.chain([headers[key]], data[key])
 
             export_from_tables(tables.items(), buffer, format=Format.JSON)
+
+
+class OnDiskExportTest(SimpleTestCase, TestFileMixin):
+
+    def test_html_export(self):
+        with Tester(self, Format.HTML) as buffer:
+            export_raw(HEADERS, DATA, buffer, format=Format.HTML)
+
+    def test_unzipped_csv_export(self):
+        with Tester(self, Format.UNZIPPED_CSV) as buffer:
+            # Only exports one sheet
+            export_raw(HEADERS, DATA, buffer, format=Format.UNZIPPED_CSV)


### PR DESCRIPTION
Note: this is a PR into branch `use-less-memory`, not `master`.

One thing I don't love about this is that it adds a dependency to `corehq.apps.app_manager.tests` because it uses the `TestFileMixin`. Should that be avoided @czue ?
Also, this relies on an as-yet unmerged change to `TestFileMixin`: https://github.com/dimagi/commcare-hq/pull/5819. I'm not sure what the appropriate way to indicate that dependency is.