### PR TITLE
Remove attachments from case history exports

### DIFF
--- a/couchexport/util.py
+++ b/couchexport/util.py
@@ -47,7 +47,7 @@ def clear_attachments(schema_or_doc):
         del schema_or_doc['case_attachments']
     if schema_or_doc:
         for action in schema_or_doc.get('actions', []):
-            if 'attachments' in action:
+            if 'attachments' in action and 'updated_unknown_properties' in action:
                 del action['attachments']
     return schema_or_doc
 

--- a/couchexport/util.py
+++ b/couchexport/util.py
@@ -45,6 +45,10 @@ def clear_attachments(schema_or_doc):
         del schema_or_doc['_attachments']
     if schema_or_doc and 'case_attachments' in schema_or_doc:
         del schema_or_doc['case_attachments']
+    if schema_or_doc:
+        for action in schema_or_doc.get('actions', []):
+            if 'attachments' in action:
+                del action['attachments']
     return schema_or_doc
 
 


### PR DESCRIPTION
Refer to: http://manage.dimagi.com/default.asp?160461#891283

This remove's attachments from case actions (which show up in the case history export)