### PR TITLE
Error converting non-ASCII filename to string

### DIFF
--- a/couchexport/writers.py
+++ b/couchexport/writers.py
@@ -292,7 +292,7 @@ class ZippedExportWriter(OnDiskExportWriter):
         archive = zipfile.ZipFile(self.file, 'w', zipfile.ZIP_DEFLATED)
         for index, name in self.table_names.items():
             path = self.tables[index].get_path()
-            archive.write(path, "{}{}".format(name, self.table_file_extension))
+            archive.write(path, u"{}{}".format(name, self.table_file_extension))
         archive.close()
         self.file.seek(0)
 


### PR DESCRIPTION
ZipFile.write accepts Unicode filenames, so don't bother converting to string.

This is to fix bug [FB 161535](http://manage.dimagi.com/default.asp?161535)