### PR TITLE
ZippedExportWriter caters for unicode and strings

### DIFF
--- a/couchexport/tests/__init__.py
+++ b/couchexport/tests/__init__.py
@@ -2,6 +2,7 @@ from .test_cleanup import *
 from .test_raw import *
 from .test_saved import *
 from .test_schema import *
+from .test_writers import *
 from couchexport.properties import parse_date_string
 
 __test__ = {

--- a/couchexport/tests/test_writers.py
+++ b/couchexport/tests/test_writers.py
@@ -1,0 +1,34 @@
+# coding: utf-8
+from couchexport.writers import ZippedExportWriter
+from django.test import SimpleTestCase
+from mock import patch, Mock
+
+
+class ZippedExportWriterTests(SimpleTestCase):
+
+    def setUp(self):
+        self.zip_file_patch = patch('zipfile.ZipFile')
+        self.MockZipFile = self.zip_file_patch.start()
+
+        self.path_mock = Mock()
+        self.path_mock.get_path.return_value = 'tmp'
+
+        self.writer = ZippedExportWriter()
+        self.writer.tables = [self.path_mock]
+        self.writer.file = Mock()
+
+    def tearDown(self):
+        self.zip_file_patch.stop()
+        del self.writer
+
+    def test_zipped_export_writer_unicode(self):
+        mock_zip_file = self.MockZipFile.return_value
+        self.writer.table_names = {0: u'ひらがな'}
+        self.writer._write_final_result()
+        mock_zip_file.write.assert_called_with('tmp', 'ひらがな.csv')
+
+    def test_zipped_export_writer_utf8(self):
+        mock_zip_file = self.MockZipFile.return_value
+        self.writer.table_names = {0: '\xe3\x81\xb2\xe3\x82\x89\xe3\x81\x8c\xe3\x81\xaa'}
+        self.writer._write_final_result()
+        mock_zip_file.write.assert_called_with('tmp', 'ひらがな.csv')

--- a/couchexport/writers.py
+++ b/couchexport/writers.py
@@ -291,8 +291,10 @@ class ZippedExportWriter(OnDiskExportWriter):
 
         archive = zipfile.ZipFile(self.file, 'w', zipfile.ZIP_DEFLATED)
         for index, name in self.table_names.items():
+            if isinstance(name, unicode):
+                name = name.encode('utf-8')
             path = self.tables[index].get_path()
-            archive.write(path, u"{}{}".format(name, self.table_file_extension))
+            archive.write(path, "{}{}".format(name, self.table_file_extension))
         archive.close()
         self.file.seek(0)
 


### PR DESCRIPTION
Tests added.

This commit is to fix [FB 161535](http://manage.dimagi.com/default.asp?161535).

Previous fix assumed that tables names would be unicode, but it seems they can
be either. This fix encodes unicode values to UTF-8-encoded strings, and
leaves string values as-is.