### PR TITLE
Prepend byte-order mark to CSV export for Excel

### DIFF
--- a/couchexport/tests/test_writers.py
+++ b/couchexport/tests/test_writers.py
@@ -1,5 +1,7 @@
 # coding: utf-8
-from couchexport.writers import ZippedExportWriter
+from cStringIO import StringIO
+from codecs import BOM_UTF8
+from couchexport.writers import ZippedExportWriter, CsvFileWriter
 from django.test import SimpleTestCase
 from mock import patch, Mock
 
@@ -32,3 +34,29 @@ class ZippedExportWriterTests(SimpleTestCase):
         self.writer.table_names = {0: '\xe3\x81\xb2\xe3\x82\x89\xe3\x81\x8c\xe3\x81\xaa'}
         self.writer._write_final_result()
         mock_zip_file.write.assert_called_with('tmp', 'ひらがな.csv')
+
+
+class CsvFileWriterTests(SimpleTestCase):
+
+    def setUp(self):
+        self.csv_file = StringIO()
+        self.fdopen_patch = patch('os.fdopen')
+        fdopen_mock = self.fdopen_patch.start()
+        fdopen_mock.return_value = self.csv_file
+        self.writer = CsvFileWriter()
+
+    def tearDown(self):
+        self.writer.close()
+        self.fdopen_patch.stop()
+
+    def test_csv_file_writer_bom(self):
+        """
+        CsvFileWriter should prepend a byte-order mark to the start of the CSV file for Excel
+        """
+        headers = ['ham', 'spam', 'eggs']
+        self.writer.open('Spam')
+        self.writer.write_row(headers)
+
+        self.csv_file.seek(0)
+        file_start = self.csv_file.read(6)
+        self.assertEqual(file_start, BOM_UTF8 + 'ham')

--- a/couchexport/writers.py
+++ b/couchexport/writers.py
@@ -1,3 +1,5 @@
+from cStringIO import StringIO
+from codecs import BOM_UTF8
 import os
 import re
 import tempfile
@@ -93,6 +95,8 @@ class ExportFileWriter(object):
 class CsvFileWriter(ExportFileWriter):
 
     def _open(self):
+        # Excel needs UTF8-encoded CSVs to start with the UTF-8 byte-order mark (FB 163268)
+        self._file.write(BOM_UTF8)
         self._csvwriter = csv.writer(self._file, csv.excel)
 
     def write_row(self, row):


### PR DESCRIPTION
Excel needs a UTF-8 BOM to recognize that a CSV is UTF-8-encoded, otherwise non-ASCII characters are not rendered correctly.

[FB 163268](http://manage.dimagi.com/default.asp?163268)

buddy @dannyroberts 
